### PR TITLE
fix: use proper URL concatenation in getURL to prevent blank screen in Electron

### DIFF
--- a/main/lib/getUrl.ts
+++ b/main/lib/getUrl.ts
@@ -1,9 +1,8 @@
 
-import path from 'path'
 import isDev from './isDev'
 
 export const domain = isDev
     ? `http://localhost:5173`
     : 'app://example.com/'
 
-export const getURL = (pathname: string) => path.join(domain, pathname)
+export const getURL = (pathname: string) => new URL(pathname, domain).toString()


### PR DESCRIPTION
## Context

Using `path.join()` to concatenate URLs caused malformed strings like ".\\http:\\localhost:5173\\", particularly on Windows. This broke the call to `win.loadURL()`, resulting in a blank Electron window when launching the built app.

## What this PR does

- Replaces `path.join(domain, pathname)` with `new URL(pathname, domain).toString()` for reliable URL handling
- Keeps compatibility for both dev and prod environments

## Why it matters

This small but critical fix allows Electron to load the correct page both during development and after build, resolving the blank screen issue.

## Testing

Tested on Windows:
- ✅ Dev mode loads localhost:5173 correctly
- ✅ Production mode loads static files correctly

## Suggestion

Instead of requiring developers to install **Bun** globally on their machine, we could consider adding it as a `devDependency` in `package.json`.